### PR TITLE
Remove the not listed section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,6 @@ $ make build
 Using the provider
 ------------------
 
-The provider isn't listed in the official Terraform repository, so using `terraform init` to download the provider won't work. To install the auth0 provider, you can [download the binary](https://github.com/alexkappa/terraform-provider-auth0/releases) and place in the directory `~/.terraform.d/plugins` (or `%APPDATA%/terraform.d/plugins/` if you're on Windows).
-
 To use the provider define the `auth0` provider in your `*.tf` file.
 
 ```


### PR DESCRIPTION
Given that the provider is listed officially and can be downloaded using `terraform init`, that section is moot.

<!--- See what makes a good Pull Request at : https://github.com/yieldr/terraform-provider-auth0/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

Changes proposed in this pull request:

* Update the README to reflect the fact that the provider is now officially listed
