### PR TITLE
add auth0_prompt resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## 0.8.0 (Unreleased)
+
+FEATURES:
+
+* **New Resource:** auth0_prompt ([#8](https://github.com/terraform-providers/terraform-provider-auth0/pull/8))
+
 ## 0.7.0 (March 23, 2020)
 
 FEATURES:

--- a/auth0/provider.go
+++ b/auth0/provider.go
@@ -50,6 +50,7 @@ func Provider() *schema.Provider {
 			"auth0_rule":            newRule(),
 			"auth0_rule_config":     newRuleConfig(),
 			"auth0_hook":            newHook(),
+			"auth0_prompt":          newPrompt(),
 			"auth0_email":           newEmail(),
 			"auth0_email_template":  newEmailTemplate(),
 			"auth0_user":            newUser(),

--- a/auth0/resource_auth0_prompt.go
+++ b/auth0/resource_auth0_prompt.go
@@ -1,0 +1,78 @@
+package auth0
+
+import (
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+
+	"gopkg.in/auth0.v3"
+	"gopkg.in/auth0.v3/management"
+)
+
+func newPrompt() *schema.Resource {
+
+	return &schema.Resource{
+
+		Create: createPrompt,
+		Read:   readPrompt,
+		Update: updatePrompt,
+		Delete: deletePrompt,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"universal_login_experience": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"new", "classic",
+				}, false),
+			},
+		},
+	}
+}
+
+func createPrompt(d *schema.ResourceData, m interface{}) error {
+	d.SetId(resource.UniqueId())
+	return updatePrompt(d, m)
+}
+
+func readPrompt(d *schema.ResourceData, m interface{}) error {
+	api := m.(*management.Management)
+	p, err := api.Prompt.Read()
+	if err != nil {
+		if mErr, ok := err.(management.Error); ok {
+			if mErr.Status() == http.StatusNotFound {
+				d.SetId("")
+				return nil
+			}
+		}
+		return err
+	}
+	d.Set("universal_login_experience", p.UniversalLoginExperience)
+	return nil
+}
+
+func updatePrompt(d *schema.ResourceData, m interface{}) error {
+	p := buildPrompt(d)
+	api := m.(*management.Management)
+	err := api.Prompt.Update(p)
+	if err != nil {
+		return err
+	}
+	return readPrompt(d, m)
+}
+
+func deletePrompt(d *schema.ResourceData, m interface{}) error {
+	d.SetId("")
+	return nil
+}
+
+func buildPrompt(d *schema.ResourceData) *management.Prompt {
+	return &management.Prompt{
+		UniversalLoginExperience: auth0.StringValue(String(d, "universal_login_experience")),
+	}
+}

--- a/auth0/resource_auth0_prompt_test.go
+++ b/auth0/resource_auth0_prompt_test.go
@@ -1,0 +1,45 @@
+package auth0
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccPrompt(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		Providers: map[string]terraform.ResourceProvider{
+			"auth0": Provider(),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPromptCreate,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_prompt.prompt", "universal_login_experience", "new"),
+				),
+			},
+			{
+				Config: testAccPromptUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_prompt.prompt", "universal_login_experience", "classic"),
+				),
+			},
+		},
+	})
+}
+
+const testAccPromptCreate = `
+
+resource "auth0_prompt" "prompt" {
+  universal_login_experience = "new"
+}
+`
+
+const testAccPromptUpdate = `
+
+resource "auth0_prompt" "prompt" {
+  universal_login_experience = "classic"
+}
+`

--- a/example/prompt/main.tf
+++ b/example/prompt/main.tf
@@ -1,0 +1,5 @@
+provider "auth0" {}
+
+resource "auth0_prompt" "prompt" {
+  universal_login_experience = "classic"
+}

--- a/website/auth0.erb
+++ b/website/auth0.erb
@@ -18,6 +18,7 @@
             <li><a href="/docs/providers/auth0/r/rule_config.html">auth0_rule_config</a></li>
             <li><a href="/docs/providers/auth0/r/rule.html">auth0_rule</a></li>
             <li><a href="/docs/providers/auth0/r/hook.html">auth0_hook</a></li>
+            <li><a href="/docs/providers/auth0/r/prompt.html">auth0_prompt</a></li>
             <li><a href="/docs/providers/auth0/r/tenant.html">auth0_tenant</a></li>
             <li><a href="/docs/providers/auth0/r/user.html">auth0_user</a></li>
           </ul>

--- a/website/docs/r/prompt.html.md
+++ b/website/docs/r/prompt.html.md
@@ -1,0 +1,24 @@
+---
+layout: "auth0"
+page_title: "Auth0: auth0_prompt"
+description: |-
+  With this resource, you can manage your Auth0 prompts, including choosing the login experience version.
+---
+
+# auth0_prompt
+
+With this resource, you can manage your Auth0 prompts, including choosing the login experience version.
+
+## Example Usage
+
+```
+resource "auth0_prompt" "example" {
+  universal_login_experience = "classic"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `universal_login_experience` - (Optional) Which login experience to use. Options include `classic` and `new`.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/yieldr/terraform-provider-auth0/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Changes proposed in this pull request:

* add new resource `auth0_prompt` (Implements [Prompt settings](https://auth0.com/docs/api/management/v2#!/Prompts/get_prompts) api)

Output from acceptance testing:

```
$ make testacc TESTS=TestAccPrompt
==> Checking that code complies with gofmt requirements...
?       github.com/terraform-providers/terraform-provider-auth0 [no test files]
=== RUN   TestAccPrompt
--- PASS: TestAccPrompt (1.95s)
PASS
coverage: 5.7% of statements
ok      github.com/terraform-providers/terraform-provider-auth0/auth0   1.960s  coverage: 5.7% of statements
testing: warning: no tests to run
PASS
coverage: 0.0% of statements
ok      github.com/terraform-providers/terraform-provider-auth0/auth0/internal/random   0.010s  coverage: 0.0% of statements [no tests to run]
testing: warning: no tests to run
PASS
coverage: 0.0% of statements
ok      github.com/terraform-providers/terraform-provider-auth0/auth0/internal/validation       0.007s  coverage: 0.0% of statements [no tests to run]
...
```
