### PR TITLE
Update role.html.md

### DIFF
--- a/website/docs/r/role.html.md
+++ b/website/docs/r/role.html.md
@@ -68,4 +68,4 @@ Arguments accepted by this resource include:
 
 Attributes exported by this resource include:
 
-* `role_id` - String. ID for the role.
+* `id` - String. ID for the role.


### PR DESCRIPTION
It appears the attribute for the role id is `id` and not `role_id`. I'm using terraform v0.12.28.

### Proposed Changes

* Change documentation of attribute name for `auth0_role` from `role_id` to `id`

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->